### PR TITLE
Fix typos in various files

### DIFF
--- a/QUICK_START_GUIDE.md
+++ b/QUICK_START_GUIDE.md
@@ -618,7 +618,7 @@ for residue in protein.residues:
 
 #### Accessing Atoms in a Protein
 
-Similary, the atoms that are part of the protein can be accesses through the `atoms` attribute.
+Similarly, the atoms that are part of the protein can be accesses through the `atoms` attribute.
 For example, to access the coordinates of all the atoms in the protein, you can use the following code:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ such infrastructure.
 
 ## Contributing to Protkit
 
-Protkit is an open source project and we welcome contributions from the community.  If you would like to contribute, please see the [Contibuting](CONTRIBUTING.md) file for details. Please also adhere to the [Code of Conduct](CODE_OF_CONDUCT.md).
+Protkit is an open source project and we welcome contributions from the community.  If you would like to contribute, please see the [Contributing](CONTRIBUTING.md) file for details. Please also adhere to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ---
 

--- a/docs/download/download.html
+++ b/docs/download/download.html
@@ -389,7 +389,7 @@ class Download:
             directory: str,
             n_jobs: int = -1) -&gt; None:
         &#34;&#34;&#34;
-        Downloads multiple Bianry CIF files from the RCSB.
+        Downloads multiple Binary CIF files from the RCSB.
 
         Args:
             pdb_ids (List[str]): The IDs of the Binary CIF files.
@@ -735,7 +735,7 @@ biological data from the internet.</p></div>
             directory: str,
             n_jobs: int = -1) -&gt; None:
         &#34;&#34;&#34;
-        Downloads multiple Bianry CIF files from the RCSB.
+        Downloads multiple Binary CIF files from the RCSB.
 
         Args:
             pdb_ids (List[str]): The IDs of the Binary CIF files.
@@ -794,7 +794,7 @@ def download_binary_cif_file_from_rcsb(
 <span>def <span class="ident">download_binary_cif_files_from_rcsb</span></span>(<span>pdb_ids: List[str], directory: str, n_jobs: int = -1) ‑> None</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Downloads multiple Bianry CIF files from the RCSB.</p>
+<div class="desc"><p>Downloads multiple Binary CIF files from the RCSB.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>pdb_ids</code></strong> :&ensp;<code>List[str]</code></dt>
@@ -817,7 +817,7 @@ def download_binary_cif_files_from_rcsb(
         directory: str,
         n_jobs: int = -1) -&gt; None:
     &#34;&#34;&#34;
-    Downloads multiple Bianry CIF files from the RCSB.
+    Downloads multiple Binary CIF files from the RCSB.
 
     Args:
         pdb_ids (List[str]): The IDs of the Binary CIF files.

--- a/docs/seq/nucleotide_sequence.html
+++ b/docs/seq/nucleotide_sequence.html
@@ -135,7 +135,7 @@ class NucleotideSequence(Sequence):
 <h2 id="notes">Notes</h2>
 <p>The sequence can be provided as a string or a list of strings.
 If provided as a string, the string will be converted to a list of strings.</p>
-<p>A sequence can be respresented by a string of single letters, such as "AGILE",
+<p>A sequence can be represented by a string of single letters, such as "AGILE",
 or a list of three-letter codes such as ["ALA", "GLY", "ILE", "LEU", "GLU"]. For
 consistency, the sequence is always represented as a list of codes.</p></div>
 <details class="source">

--- a/docs/seq/sequence.html
+++ b/docs/seq/sequence.html
@@ -80,7 +80,7 @@ class Sequence(ExtendedAttributes):
             The sequence can be provided as a string or a list of strings.
             If provided as a string, the string will be converted to a list of strings.
 
-            A sequence can be respresented by a string of single letters, such as &#34;AGILE&#34;,
+            A sequence can be represented by a string of single letters, such as &#34;AGILE&#34;,
             or a list of three-letter codes such as [&#34;ALA&#34;, &#34;GLY&#34;, &#34;ILE&#34;, &#34;LEU&#34;, &#34;GLU&#34;]. For
             consistency, the sequence is always represented as a list of codes.
         &#34;&#34;&#34;
@@ -280,7 +280,7 @@ class Sequence(ExtendedAttributes):
 <h2 id="notes">Notes</h2>
 <p>The sequence can be provided as a string or a list of strings.
 If provided as a string, the string will be converted to a list of strings.</p>
-<p>A sequence can be respresented by a string of single letters, such as "AGILE",
+<p>A sequence can be represented by a string of single letters, such as "AGILE",
 or a list of three-letter codes such as ["ALA", "GLY", "ILE", "LEU", "GLU"]. For
 consistency, the sequence is always represented as a list of codes.</p></div>
 <details class="source">
@@ -307,7 +307,7 @@ consistency, the sequence is always represented as a list of codes.</p></div>
             The sequence can be provided as a string or a list of strings.
             If provided as a string, the string will be converted to a list of strings.
 
-            A sequence can be respresented by a string of single letters, such as &#34;AGILE&#34;,
+            A sequence can be represented by a string of single letters, such as &#34;AGILE&#34;,
             or a list of three-letter codes such as [&#34;ALA&#34;, &#34;GLY&#34;, &#34;ILE&#34;, &#34;LEU&#34;, &#34;GLU&#34;]. For
             consistency, the sequence is always represented as a list of codes.
         &#34;&#34;&#34;

--- a/notebooks/downloading_data.ipynb
+++ b/notebooks/downloading_data.ipynb
@@ -135,7 +135,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "Protkit contains a number of modules organised by the functionality they provide. In this demo, we are interested in downloading and file handling capabilties. To use these, we import the relevant modules and classes."
+        "Protkit contains a number of modules organised by the functionality they provide. In this demo, we are interested in downloading and file handling capabilities. To use these, we import the relevant modules and classes."
       ],
       "metadata": {
         "id": "k87BmqUVbWU9"

--- a/protkit/download/download.py
+++ b/protkit/download/download.py
@@ -343,7 +343,7 @@ class Download:
             directory: str,
             n_jobs: int = -1) -> None:
         """
-        Downloads multiple Bianry CIF files from the RCSB.
+        Downloads multiple Binary CIF files from the RCSB.
 
         Args:
             pdb_ids (List[str]): The IDs of the Binary CIF files.

--- a/protkit/seq/sequence.py
+++ b/protkit/seq/sequence.py
@@ -43,7 +43,7 @@ class Sequence(ExtendedAttributes):
             The sequence can be provided as a string or a list of strings.
             If provided as a string, the string will be converted to a list of strings.
 
-            A sequence can be respresented by a string of single letters, such as "AGILE",
+            A sequence can be represented by a string of single letters, such as "AGILE",
             or a list of three-letter codes such as ["ALA", "GLY", "ILE", "LEU", "GLU"]. For
             consistency, the sequence is always represented as a list of codes.
         """


### PR DESCRIPTION
Fix some typos found by running [`codespell`](https://github.com/codespell-project/codespell) on the codebase. The exact command was:

```
codespell -L ser,conect,nd,te   
```

The words after `-L` flag are a few false positives that need to be ignored.